### PR TITLE
fix: json_generic_api response is now a escaped json string

### DIFF
--- a/sdk/sdkcore/json_generic_api.go
+++ b/sdk/sdkcore/json_generic_api.go
@@ -2,7 +2,6 @@ package forticlient
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 )
 
@@ -38,10 +37,18 @@ func (c *FortiSDKClient) JsonGenericAPI(data string, wsParams map[string]string)
 		c.logoutSession(session)
 	}
 
-	if err == nil {
-		output = string(fmt.Sprintf("%v", result))
-		log.Printf("Successful\n")
+	if err != nil {
+		return
 	}
+
+	var resultBytes []byte
+	resultBytes, err = json.Marshal(result)
+	if err != nil {
+		return
+	}
+
+	output = string(resultBytes)
+	log.Printf("Successful\n")
 
 	return
 }


### PR DESCRIPTION
Resolve issue #78 

The `json_generic_api` resource variable response does not return an escaped json string.

Example:
```terraform
resource "fortimanager_json_generic_api" "test2" {
  json_content = <<JSON
{
    "method": "get",
    "params": [
        {
            "url": "/pm/config/global/pkg/default/global/footer/consolidated/policy"
        }
    ]
}
JSON
}

output "name2" {
  value = jsondecode(fortimanager_json_generic_api.test2.response)
}
```

Output:
```
name2 = "map[result:[map[data:[] status:map[code:0 message:OK] url:/pm/config/global/pkg/default/global/footer/consolidated/policy]]]"
```

Output after the result have been converted to json:
```
name2 = "{\"result\":[{\"data\":[],\"status\":{\"code\":0,\"message\":\"OK\"},\"url\":\"/pm/config/global/pkg/default/global/footer/consolidated/policy\"}]}"
```